### PR TITLE
Deprecate setupDates()

### DIFF
--- a/Tests/Entity/CreatedUpdatedTraitTest.php
+++ b/Tests/Entity/CreatedUpdatedTraitTest.php
@@ -26,6 +26,21 @@ class CreatedUpdatedTraitTest extends TestCase
      * @dataProvider provideMock
      * @param CreatedUpdatedTrait|\PHPUnit\Framework\MockObject\MockObject $mock
      */
+    public function testInitializeDates(CreatedUpdatedTrait|\PHPUnit\Framework\MockObject\MockObject $mock)
+    {
+        $now = $this->faker->dateTime();
+        $mock->initializeDates();
+        self::assertEquals($mock->getCreatedAt(), $mock->getUpdatedAt());
+        $mock->setCreatedAt($now);
+        self::assertEquals($now, $mock->getCreatedAt());
+        self::assertNotEquals($now, $mock->getUpdatedAt());
+    }
+
+    /**
+     * @dataProvider provideMock
+     * @param CreatedUpdatedTrait|\PHPUnit\Framework\MockObject\MockObject $mock
+     * @group legacy
+     */
     public function testSetupDates(CreatedUpdatedTrait|\PHPUnit\Framework\MockObject\MockObject $mock)
     {
         $now = $this->faker->dateTime();

--- a/src/Entity/CreatedUpdatedTrait.php
+++ b/src/Entity/CreatedUpdatedTrait.php
@@ -7,6 +7,7 @@ namespace Bytes\ResponseBundle\Entity;
 use DateTime;
 use DateTimeInterface;
 use Doctrine\ORM\Mapping as ORM;
+use JetBrains\PhpStorm\Deprecated;
 
 /**
  * Trait CreatedUpdatedTrait
@@ -48,7 +49,7 @@ trait CreatedUpdatedTrait
     /**
      * @return $this
      */
-    public function setupDates(): self
+    public function initializeDates(): self
     {
         $dateTime = new DateTime();
         $this->setCreatedAt($dateTime);
@@ -57,6 +58,15 @@ trait CreatedUpdatedTrait
         }
 
         return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    #[Deprecated(reason: 'since 4.1.1, use initializeDates() instead', replacement: '%class%->initializeDates()')]
+    public function setupDates(): self
+    {
+        return $this->initializeDates();
     }
 
     /**


### PR DESCRIPTION
Deprecate setupDates() and instead use the renamed initializeDates() to prevent Serializer conflicts