### PR TITLE
Throw Exception When Missing Arguments in ComparableDateInterval

### DIFF
--- a/Tests/Objects/ComparableDateIntervalTest.php
+++ b/Tests/Objects/ComparableDateIntervalTest.php
@@ -8,6 +8,7 @@ use DateInterval;
 use Exception;
 use Faker\Factory;
 use Generator;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -144,6 +145,46 @@ class ComparableDateIntervalTest extends TestCase
         $this->assertEquals(105, ComparableDateInterval::getTotalMinutes(new DateInterval('PT1H45M29S'), 'round'));
         $this->assertEquals(62, ComparableDateInterval::getTotalMinutes(new DateInterval('PT1H1M1S'), 'ceil'));
         $this->assertEquals(179, ComparableDateInterval::getTotalMinutes(new DateInterval('PT2H59M59S'), 'floor'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIntervalToHoursMissingSecondArgument()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        ComparableDateInterval::getTotalHours(new DateInterval('PT15M'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIntervalToMinutesMissingSecondArgument()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        ComparableDateInterval::getTotalMinutes(new DateInterval('PT15M'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIntervalToHoursNamedSecondArgument()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        ComparableDateInterval::getTotalHours(new DateInterval('PT15M'), manipulator: 'ceil');
+    }
+
+    /**
+     * @return void
+     */
+    public function testIntervalToMinutesNamedSecondArgument()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        ComparableDateInterval::getTotalMinutes(new DateInterval('PT15M'), manipulator: 'ceil');
     }
 
     /**

--- a/src/Objects/ComparableDateInterval.php
+++ b/src/Objects/ComparableDateInterval.php
@@ -8,6 +8,7 @@ use Bytes\ResponseBundle\Exception\LargeDateIntervalException;
 use DateInterval;
 use DateTime;
 use Exception;
+use InvalidArgumentException;
 use LogicException;
 
 /**
@@ -108,6 +109,9 @@ class ComparableDateInterval extends DateInterval
      */
     public static function __callStatic(string $name, array $arguments)
     {
+        if(!array_key_exists(0, $arguments) || !array_key_exists(1, $arguments)) {
+            throw new InvalidArgumentException('Named arguments are not currently supported with the ' . __METHOD__ . ' method.');
+        }
         switch (strtolower($name)) {
             case 'gettotalminutes':
                 return static::getTotalByTimeType($arguments[0], 'MINUTES', $arguments[1]);


### PR DESCRIPTION
Temporarily throw an InvalidArgumentException when named arguments are used (or the manipulator argument is missing)